### PR TITLE
Support for multiple target nodes

### DIFF
--- a/src/commands/sync-files.js
+++ b/src/commands/sync-files.js
@@ -17,13 +17,13 @@ const asyncIteratorToList = async (iterator) => {
 }
 
 const collectUnsyncedFiles = async ({ fromClient, toClient, skipExisting, fileList }) => {
-  let fromPinnedFiles = fileList ? fileList : await asyncIteratorToList(fromClient.pin.ls)
+  let fromPinnedFiles = fileList ? fileList : await asyncIteratorToList(fromClient.pin.remote.ls)
 
   // If --skip-existing is provided, we obtain a list of all pinned files from
   // the target node. If not, we assume none of the source files exist on the
   // target node yet.
   if (skipExisting) {
-    let toPinnedFiles = await asyncIteratorToList(toClient.pin.ls)
+    let toPinnedFiles = await asyncIteratorToList(toClient.pin.remote.ls)
     return fromPinnedFiles.filter(
       sourceFile =>
         !toPinnedFiles.find(targetFile => sourceFile.cid.equals(targetFile.cid)),
@@ -67,7 +67,7 @@ ${chalk.bold('ipfs-sync sync-files')} [options]
 ${chalk.dim('Options:')}
   -h, --help                    Show usage information
   --from <URL>                  Source IPFS node
-  --to <URL>                    Target IPFS node
+  --to <URL>                    Target IPFS node(s). It accepts a comma separated list of URLs
   --file-list <FILE>            File with one IPFS cid to sync per line
   --skip-existing               Skip files that already exist on the target IPFS node
   --retries <NUMBER>            Number of times to try to download a file from Source IPFS node
@@ -82,7 +82,7 @@ module.exports = {
     let { print } = toolbox
 
     // Parse CLI parameters
-    let { h, help, from, to, skipExisting, fileList, retries, retryWait } = toolbox.parameters.options
+    let { h, help, from, to, skipExisting, fileList: fileListPath, retries, retryWait } = toolbox.parameters.options
 
     // Show help text if asked for
     if (h || help) {
@@ -96,95 +96,100 @@ module.exports = {
       return
     }
 
-    print.info(`Syncing files`)
-    print.info(`Source node (--from): ${from}`)
-    print.info(`Target node (--to): ${to}`)
-    print.info(`Retries: ${retries || DEFAULT_RETRIES} `)
-
+    targets = to.split(',')
     let fromClient = ipfs.createIpfsClient(from)
-    let toClient = ipfs.createIpfsClient(to)
 
-    // Read file list from the `--list` file
-    fileList = fileList
-      ? fs
-          .readFileSync(fileList, 'utf-8')
-          .trim()
-          .split('\n')
-          .map(cid => ({ cid: CID.parse(cid) }))
-      : undefined
-
-    // Obtain a list of all pinned files from both nodes
-    let unsyncedFiles = await collectUnsyncedFiles({
-      fromClient,
-      toClient,
-      fileList,
-      skipExisting,
-    })
-
-    print.info(`${unsyncedFiles.length} files need to be synced`)
-    if (unsyncedFiles.length > 0) {
+    for (const [index, target] of targets.entries()) {
+      print.info(`Syncing files`)
+      print.info(`Source node (--from): ${from}`)
+      targets.length > 1 ? 
+        print.info(`Target node (--to) [${index + 1}/${targets.length}]: ${target}`) :
+        print.info(`Target node (--to): ${target}`)
+  
+      let toClient = ipfs.createIpfsClient(target)
+  
+      // Read file list from the `--list` file
+      fileList = fileListPath
+        ? fs
+            .readFileSync(fileListPath, 'utf-8')
+            .trim()
+            .split('\n')
+            .map(cid => ({ cid: CID.parse(cid) }))
+        : undefined
+  
+      // Obtain a list of all pinned files from both nodes
+      let unsyncedFiles = await collectUnsyncedFiles({
+        fromClient,
+        toClient,
+        fileList,
+        skipExisting,
+      })
+  
+      print.info(`${unsyncedFiles.length} files need to be synced`)
+      if (unsyncedFiles.length > 0) {
+        print.info(`---`)
+      }
+  
+      let syncResult = {
+        syncedFiles: [],
+        failedFiles: [],
+        skippedDirectories: [],
+      }
+  
+      await batchPromises(
+        // Sync in batches of 10 files
+        10,
+        // Inject file indices
+        unsyncedFiles.map((file, index) => {
+          file.index = index
+          return file
+        }),
+        // Upload promise
+        async sourceFile => {
+          let totalFiles = unsyncedFiles.length
+          let label = `${sourceFile.index}/${totalFiles} (${sourceFile.cid})`
+  
+          print.info(`${label}: Syncing`)
+  
+          // Download file
+          print.info(`${label}: Retrieving file`)
+          let data
+          try {
+            data = await fetchData({print, fromClient, sourceFile, label, syncResult, retries, retryWait})
+          } catch (e) {
+            print.warning(`${label}: Failed to retrieve file: ${e.message}`)
+            return
+          }
+  
+          // Upload file
+          print.info(`${label}: Uploading file`)
+          let targetFile
+          try {
+            targetFile = await toClient.add(data)
+          } catch (e) {
+            throw new Error(`${label}: Failed to upload file: ${e.message}`)
+          }
+  
+          // Verify integrity before and after
+          if (sourceFile.cid.equals(targetFile.cid)) {
+            print.info(`${label}: File synced successfully`)
+            syncResult.syncedFiles.push(sourceFile.cid)
+          } else {
+            throw new Error(
+              `${label}: Failed to sync file: Uploaded file cid differs: ${targetFile.cid}`,
+            )
+          }
+        },
+      )
+  
       print.info(`---`)
-    }
-
-    let syncResult = {
-      syncedFiles: [],
-      failedFiles: [],
-      skippedDirectories: [],
-    }
-
-    await batchPromises(
-      // Sync in batches of 10 files
-      10,
-      // Inject file indices
-      unsyncedFiles.map((file, index) => {
-        file.index = index
-        return file
-      }),
-      // Upload promise
-      async sourceFile => {
-        let totalFiles = unsyncedFiles.length
-        let label = `${sourceFile.index}/${totalFiles} (${sourceFile.cid})`
-
-        print.info(`${label}: Syncing`)
-
-        // Download file
-        print.info(`${label}: Retrieving file`)
-        let data
-        try {
-          data = await fetchData({print, fromClient, sourceFile, label, syncResult, retries, retryWait})
-        } catch (e) {
-          print.warning(`${label}: Failed to retrieve file: ${e.message}`)
-          return
-        }
-
-        // Upload file
-        print.info(`${label}: Uploading file`)
-        let targetFile
-        try {
-          targetFile = await toClient.add(data)
-        } catch (e) {
-          throw new Error(`${label}: Failed to upload file: ${e.message}`)
-        }
-
-        // Verify integrity before and after
-        if (sourceFile.cid.equals(targetFile.cid)) {
-          print.info(`${label}: File synced successfully`)
-          syncResult.syncedFiles.push(sourceFile.cid)
-        } else {
-          throw new Error(
-            `${label}: Failed to sync file: Uploaded file cid differs: ${targetFile.cid}`,
-          )
-        }
-      },
-    )
-
-    print.info(`---`)
-    print.info(`${syncResult.syncedFiles.length}/${unsyncedFiles.length} files synced`)
-    print.info(`${syncResult.skippedDirectories.length} skipped (directories)`)
-    print.info(`${syncResult.failedFiles.length} failed`)
-
-    if (syncResult.failedFiles.length > 0) {
-      process.exitCode = 1
-    }
+      print.info(`${syncResult.syncedFiles.length}/${unsyncedFiles.length} files synced`)
+      print.info(`${syncResult.skippedDirectories.length} skipped (directories)`)
+      print.info(`${syncResult.failedFiles.length} failed`)
+  
+      if (syncResult.failedFiles.length > 0) {
+        process.exitCode = 1
+      }
+    } 
   },
 }

--- a/src/commands/sync-files.js
+++ b/src/commands/sync-files.js
@@ -17,13 +17,13 @@ const asyncIteratorToList = async (iterator) => {
 }
 
 const collectUnsyncedFiles = async ({ fromClient, toClient, skipExisting, fileList }) => {
-  let fromPinnedFiles = fileList ? fileList : await asyncIteratorToList(fromClient.pin.remote.ls)
+  let fromPinnedFiles = fileList ? fileList : await asyncIteratorToList(fromClient.pin.ls)
 
   // If --skip-existing is provided, we obtain a list of all pinned files from
   // the target node. If not, we assume none of the source files exist on the
   // target node yet.
   if (skipExisting) {
-    let toPinnedFiles = await asyncIteratorToList(toClient.pin.remote.ls)
+    let toPinnedFiles = await asyncIteratorToList(toClient.pin.ls)
     return fromPinnedFiles.filter(
       sourceFile =>
         !toPinnedFiles.find(targetFile => sourceFile.cid.equals(targetFile.cid)),

--- a/src/ipfs.js
+++ b/src/ipfs.js
@@ -11,22 +11,8 @@ const createIpfsClient = node => {
 The URL must be of the following format: http(s)://host[:port]/[path]`)
   }
 
-  // Set the port to 443 or 80 explicitly, if no port was provided
-  let port = url.port
-    ? url.port
-    : url.protocol === 'https:'
-    ? 443
-    : url.protocol === 'http'
-    ? 80
-    : undefined
-
   // Connect to the IPFS node (if a node address was provided)
-  return create({
-    protocol: url.protocol.replace(/[:]+$/, ''),
-    host: url.hostname,
-    port: port,
-    path: url.pathname.replace(/\/$/, '') + '/api/v0/',
-  })
+  return create(node.replace(/\/$/, '') + '/api/v0')
 }
 
 module.exports = {


### PR DESCRIPTION
This lets the user specify more than one target node for files to be uploaded. 
They can use a comma separated list of URLs like this: 
```
ipfs-sync sync-files --from https://ipfs.io --to http://127.0.0.1:5001/,https://api.staging.thegraph.com/ipfs/
``` 

It also fixes a bug where the subpath was getting removed from the node URL.